### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ def versions = [
     junitPlatform           : '1.8.2',
     lombok                  : '1.18.22',
     springBoot              : springBoot.class.package.implementationVersion,
-    reformLoggingVersion    : '5.1.9',
+    reformLoggingVersion    : '6.0.1',
     log4JVersion            : '2.17.1'
 ]
 


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.